### PR TITLE
✅ [ADD] Skip changelog during prerelease

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -8,7 +8,7 @@ const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 
 module.exports = function (args, newVersion) {
-  if (args.skip.changelog) return Promise.resolve()
+  if (args.skip.changelog || args.prerelease) return Promise.resolve()
   return runLifecycleScript(args, 'prechangelog')
     .then(() => {
       return outputChangelog(args, newVersion)


### PR DESCRIPTION
During a prerelease we don't want to generate a changelog because we can have unnecessary conflict 